### PR TITLE
Allow setting CLD2_PATH in environment

### DIFF
--- a/README
+++ b/README
@@ -16,8 +16,8 @@ To build:
     (detects 163 languages).  Install those libraries somewhere on
     your LD_LIBRARY_PATH, for example copy them into /usr/lib64.
 
-  * Edit both setup.py and setup_full.py: edit CLD2_PATH to point to
-    where you checked out the CLD2 sources.
+  * Define the CLD2_PATH environment variable to point to where you
+    checked out the CLD2 sources: export CLD2_PATH='/path/to/cld2'
 
   * python setup.py build
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ import sys
 import os
 
 # NOTE: change this to point to where you checked out the CLD2
-# sources:
-CLD2_PATH = '/usr/include/cld2'
+# sources, or define the CLD2_PATH environment variable
+CLD2_PATH = os.environ.get('CLD2_PATH', '/usr/include/cld2')
 
 # Test suite
 class cldtest(distutils.core.Command):

--- a/setup_full.py
+++ b/setup_full.py
@@ -22,8 +22,8 @@ import sys
 import os
 
 # NOTE: change this to point to where you checked out the CLD2
-# sources:
-CLD2_PATH = '/usr/include/cld2'
+# sources, or define the CLD2_PATH environment variable
+CLD2_PATH = os.environ.get('CLD2_PATH', '/usr/include/cld2')
 
 # Test suite
 class cldtest(distutils.core.Command):


### PR DESCRIPTION
CLD2 and python-cld2 are currently difficult to deploy. Eventually CLD2 should install to standard locations and python-cld2 should find the files it needs in those locations, but for now, how about not requiring to edit setup.py? This would make my life a bit easier. :)

Thanks for python-cld2!
