### PR TITLE
Cure Memory leak with returnVectors enabled (issue #2)

### DIFF
--- a/pycldmodule.cc
+++ b/pycldmodule.cc
@@ -217,6 +217,7 @@ detect(PyObject *self, PyObject *args, PyObject *kwArgs) {
                            textBytesFound,
                            details,
                            resultChunks);
+    Py_DECREF(resultChunks);
   } else {
     result = Py_BuildValue("(OiO)",
                            isReliable ? Py_True : Py_False,


### PR DESCRIPTION
Patch applied per issue #2. This has been in production here since 2015 with no leaks or other issues.